### PR TITLE
Fedora Compatibility for Certificate Update

### DIFF
--- a/create_bbb.sh
+++ b/create_bbb.sh
@@ -216,7 +216,14 @@ else
     sudo mkdir /usr/local/share/ca-certificates/bbb-dev/ -p
     sudo cp $HOME/$NAME/certs-source/bbb-dev-ca.crt /usr/local/share/ca-certificates/bbb-dev/
     sudo chmod 644 /usr/local/share/ca-certificates/bbb-dev/bbb-dev-ca.crt
-    sudo update-ca-certificates
+    
+    if command -v update-ca-certificates >/dev/null 2>&1; then
+        sudo update-ca-certificates
+    elif command -v update-ca-trust >/dev/null 2>&1; then
+        sudo update-ca-trust extract
+    else
+        echo "Warning: No certificate update tool found."
+    fi
 
     #Generate a certificate for your first local BBB server
     cd $HOME/$NAME/certs-source/


### PR DESCRIPTION
## Summary

This PR improves the certificate update process in the BigBlueButton Docker development script by adding Fedora compatibility. The script originally relied solely on `sudo update-ca-certificates`, a command available on Debian/Ubuntu systems but not on Fedora (and other Red Hat-based systems). This update conditionally checks for the available certificate update tool and uses Fedora's `sudo update-ca-trust extract` when needed.

## Changes Made

- **Conditional Certificate Update:**
  - The script first checks if the `update-ca-certificates` command exists (used in Debian/Ubuntu).
  - If not found, it checks for `update-ca-trust` (used in Fedora and other Red Hat-based systems) and executes `sudo update-ca-trust extract`.
  - If neither command exists, a warning message is displayed.
  
  **Code snippet:**
  ```sh
  if command -v update-ca-certificates >/dev/null 2>&1; then
    sudo update-ca-certificates
  elif command -v update-ca-trust >/dev/null 2>&1; then
    sudo update-ca-trust extract
  else
    echo "Warning: No certificate update tool found."
  fi
- **Backward Compatibility:**
    - Existing behavior on Debian/Ubuntu remains unchanged.
    - Fedora and Red Hat-based systems users now benefit from a compatible command, ensuring the certificate update process works across platforms.

## Testing

- **On Ubuntu/Debian:**
  - The script uses sudo update-ca-certificates as before, and the certificate update process runs successfully.
- **On Fedora:**
  - The script now detects the absence of update-ca-certificates and correctly calls sudo update-ca-trust extract to update the CA trust store.
  - Testing on Fedora confirmed that the script runs without errors.